### PR TITLE
generic-doublificate test should not pass with constant return vals

### DIFF
--- a/src/iloveponies/tests/i_am_a_horse_in_the_land_of_booleans.clj
+++ b/src/iloveponies/tests/i_am_a_horse_in_the_land_of_booleans.clj
@@ -42,7 +42,9 @@
 (facts "generic-doublificate" {:exercise 6
                                :points 1}
   (generic-doublificate 1)        => 2
+  (generic-doublificate 2)        => 4
   (generic-doublificate [1 2])    => 4
+  (generic-doublificate [1 2 3])  => 6
   (generic-doublificate '(65 21)) => 4
   (generic-doublificate {})       => nil
   (generic-doublificate [])       => nil


### PR DESCRIPTION
The number-argument test for `generic-doublificate` passes if the solution always returns `2` for number arguments - this PR adds one more number-argument test. The original issue appeared in the implementation of `generic-doublificate` from [this PR](https://github.com/iloveponies/i-am-a-horse-in-the-land-of-booleans/pull/394), which passes Travis tests, but fails for any number argument other than 1. (Looks like it's just a typo, but it's a missed lesson)

``` clojure
(defn generic-doublificate [x]
  (cond
   (number? x) (*  2)
   (empty? x) nil
   (or (list? x) (vector? x)) (* 2 (count x))
   :else true))
```

Similarly, the list/vector argument tests for `generic-doublificate` pass if the return value is always `4` - this PR adds one more test with more than two elements in the list argument to test for variable return values.
